### PR TITLE
Variable bttn depending on treeviewselect

### DIFF
--- a/Db_setup.py
+++ b/Db_setup.py
@@ -54,7 +54,7 @@ printDB()
 try:
     db_conn.execute("CREATE TABLE ItemPack (ID INTEGER PRIMARY KEY "
                     "AUTOINCREMENT NOT NULL, ProductName TEXT NOT NULL, "
-                    "PackName TEXT);")  # DATA Types: NULL, INTEGER, TEXT, REAL (floating numbers), BLOB (binary data)
+                    "PackName TEXT, StartDate TEXT, EndDate TEXT);")  # DATA Types: NULL, INTEGER, TEXT, REAL (floating numbers), BLOB (binary data)
     db_conn.commit()
 
 except sqlite3.OperationalError:

--- a/Hike_v26.py
+++ b/Hike_v26.py
@@ -4,7 +4,7 @@ import numpy as np
 import tkinter.font as tkFont
 import tkinter.ttk as ttk
 from tkinter import messagebox
-from MyGUIlib25 import ItemList, ChoiceInventory, LoadPacks, ChildWindow, ChildWindowEdit, NewTab
+from MyGUIlib25 import ItemList, ChoiceInventory, LoadPacks, ChildWindow, ChildWindowEdit, NewTab, changeableButton
 
 """
 IDEAS:
@@ -502,10 +502,15 @@ class Inventory:
 
         # Create an ITEMS-obect (ie. the list with all items)
         self.items = ItemList(tree_frame, data, header, db_conn)
+        # print(self.track_selection())
 
         # Buttons for adding and removing items in Inventory
         self.bttn_add_item = ttk.Button(bttn_frame, text="Add Item", command=self.create_add_to_tree_window)
-        self.bttn_remove_item = ttk.Button(bttn_frame, text="Remove Item", command=self.items.remove_from_tree)
+        self.bttn_remove_item = changeableButton(bttn_frame, text="Remove Item", command=self.items.remove_from_tree)
+        self.bttn_remove_item.change_state(DISABLED)
+
+        self.items.track_bttn = self.bttn_remove_item  # Ugly and bad, don't do this!
+
         self.bttn_edit_item = ttk.Button(bttn_frame, text="Edit Item", command=self.create_edit_item_window)
 
         self.bttn_add_item.pack(side="left")

--- a/MyGUIlib25.py
+++ b/MyGUIlib25.py
@@ -6,6 +6,14 @@ from tkinter import *
 from tkinter import messagebox
 import sqlite3
 
+class changeableButton(ttk.Button):
+
+    def change_state(self, state):
+        if state == 'enabl':
+            self['state'] = NORMAL
+        elif state == 'disabl':
+            self['state'] = DISABLED
+
 class changeableEntry(ttk.Entry):
     """Class that defines the ttk.Style of the application"""
 
@@ -45,9 +53,7 @@ class changeableEntry(ttk.Entry):
 
     def is_empty(self):
         """Returns True if the chabgeableEntry has no value in it, otherwise False"""
-
         val = self.get()
-
         if val is not None:
             return False
         else:
@@ -265,6 +271,9 @@ class ItemList(SearchableTree):
         self.update_weight()
         w_label_str = Label(self.master, text="Total inventory weight [g]:")
         w_label_str.grid(column=7, row=9, sticky="NE", padx=2, pady=2)
+
+        # self.tree.bind('<TreeviewSelect>', bttn_state('enabl'))
+        # self.tree.bind('FocusOut', 'disabl')
 
         # print(self.tree.item('I001')['values'])
 

--- a/MyGUIlib25.py
+++ b/MyGUIlib25.py
@@ -9,10 +9,11 @@ import sqlite3
 class changeableButton(ttk.Button):
 
     def change_state(self, state):
-        if state == 'enabl':
-            self['state'] = NORMAL
-        elif state == 'disabl':
-            self['state'] = DISABLED
+        # if state == 'enabl':
+        #     self['state'] = NORMAL
+        # elif state == 'disabl':
+        #     self['state'] = DISABLED
+        self['state'] = state # if you do not want an if :)
 
 class changeableEntry(ttk.Entry):
     """Class that defines the ttk.Style of the application"""
@@ -1074,7 +1075,8 @@ class ChildWindow:
     def get_entries(self):
         """Returns the entered values in a list"""
 
-        if {self.ent_pn.get()}.issubset([i[0] for i in
+        # Check if product name exists already. Use "...".lower() to compare lowercase strings
+        if {self.ent_pn.get().lower()}.issubset([i[0].lower() for i in
                                          self.items.get_list_of_items()]):  # in this case '{..}' creates a set, which is slightly faster
             # The product name for the new item, that we want to add, already exists in the treeview, so
             # we must choose a new item name
@@ -1134,7 +1136,9 @@ class ChildWindowEdit(ChildWindow):
                           self.ent_name.get(), self.combo.get()]  # ent_cat is alt., if we don not use combobox
 
         # Can this be the same in both ChildWindows? So no need to override method?
-        if self.ent_pn.get() != self.orig_pn:
+
+        # Chek if product name already exists
+        if self.ent_pn.get().lower() != self.orig_pn.lower():
             if {self.ent_pn.get()}.issubset([i[0] for i in
                                              self.items.get_list_of_items()]):  # in this case '{..}' creates a set, which is slightly faster
                 # The product name for the new item, that we want to add, already exists in the treeview, so


### PR DESCRIPTION
### Added auto-changing button
The <strong>*Remove items*</strong>-button in the main tab is now disabled if the user has not specifically selected a row in the tree (with items in inventory); thus, there will be no errors raised, should the user try t remove an item, without first having selected a row in the treeview.
<br>
<strong>TBU:</strong> This same functionality should be applied to the <strong>*Edit item*</strong>-button